### PR TITLE
Extracredit arij

### DIFF
--- a/api/src/functions/createAuthorization/createAuthorization.js
+++ b/api/src/functions/createAuthorization/createAuthorization.js
@@ -30,10 +30,9 @@ export const handler = async (event, context) => {
    * https://console.cloud.google.com/apis/credentials.
    */
   const oauth2Client = new google.auth.OAuth2(
-    process.env.CLIENT_ID,
-    process.env.CLIENT_SECRET,
-    //process.env.REDIRECT_URL
-    'http://localhost:8910'
+    process.env.YOUR_CLIENT_ID,
+    process.env.YOUR_CLIENT_SECRET,
+    process.env.YOUR_REDIRECT_URL
   )
 
   // Access scopes for calendar events.

--- a/api/src/functions/createAuthorization/createAuthorization.js
+++ b/api/src/functions/createAuthorization/createAuthorization.js
@@ -30,13 +30,16 @@ export const handler = async (event, context) => {
    * https://console.cloud.google.com/apis/credentials.
    */
   const oauth2Client = new google.auth.OAuth2(
-    process.env.YOUR_CLIENT_ID,
-    process.env.YOUR_CLIENT_SECRET,
-    process.env.YOUR_REDIRECT_URL
+    process.env.CLIENT_ID,
+    process.env.CLIENT_SECRET,
+    process.env.REDIRECT_URL
   )
 
   // Access scopes for calendar events.
-  const scopes = ['https://www.googleapis.com/auth/calendar.events']
+  const scopes = [
+    'https://www.googleapis.com/auth/calendar',
+    'https://www.googleapis.com/auth/calendar.events',
+  ]
 
   // Generate a url that asks permissions for the calendar scope
   const authorizationUrl = oauth2Client.generateAuthUrl({
@@ -57,5 +60,37 @@ export const handler = async (event, context) => {
     body: JSON.stringify({
       data: authorizationUrl,
     }),
+  }
+}
+
+export const oauthCallback = async (event, context) => {
+  logger.info('Invoked oauthCallback function')
+  console.log(event)
+  console.log(context)
+
+  const { google } = require('googleapis')
+
+  const oauth2Client = new google.auth.OAuth2(
+    process.env.CLIENT_ID,
+    process.env.CLIENT_SECRET,
+    process.env.REDIRECT_URL
+  )
+
+  // Extract the authorization code from the query parameters
+  const { queryStringParameters } = event
+  const { code } = queryStringParameters.code
+
+  // Exchange the authorization code for access and refresh tokens
+  const { tokens } = await oauth2Client.getToken(code)
+  console.log(tokens)
+  // Now you have the access and refresh tokens
+  const accessToken = tokens.access_token
+  const refreshToken = tokens.refresh_token
+
+  // Continue with your logic for storing and utilizing the tokens
+
+  return {
+    statusCode: 200,
+    body: 'Authorization code received and tokens retrieved successfully.',
   }
 }

--- a/api/src/functions/createAuthorization/createAuthorization.js
+++ b/api/src/functions/createAuthorization/createAuthorization.js
@@ -32,7 +32,8 @@ export const handler = async (event, context) => {
   const oauth2Client = new google.auth.OAuth2(
     process.env.CLIENT_ID,
     process.env.CLIENT_SECRET,
-    process.env.REDIRECT_URL
+    //process.env.REDIRECT_URL
+    'http://localhost:8910'
   )
 
   // Access scopes for calendar events.
@@ -60,37 +61,5 @@ export const handler = async (event, context) => {
     body: JSON.stringify({
       data: authorizationUrl,
     }),
-  }
-}
-
-export const oauthCallback = async (event, context) => {
-  logger.info('Invoked oauthCallback function')
-  console.log(event)
-  console.log(context)
-
-  const { google } = require('googleapis')
-
-  const oauth2Client = new google.auth.OAuth2(
-    process.env.CLIENT_ID,
-    process.env.CLIENT_SECRET,
-    process.env.REDIRECT_URL
-  )
-
-  // Extract the authorization code from the query parameters
-  const { queryStringParameters } = event
-  const { code } = queryStringParameters.code
-
-  // Exchange the authorization code for access and refresh tokens
-  const { tokens } = await oauth2Client.getToken(code)
-  console.log(tokens)
-  // Now you have the access and refresh tokens
-  const accessToken = tokens.access_token
-  const refreshToken = tokens.refresh_token
-
-  // Continue with your logic for storing and utilizing the tokens
-
-  return {
-    statusCode: 200,
-    body: 'Authorization code received and tokens retrieved successfully.',
   }
 }

--- a/api/src/services/googlecalendar.js
+++ b/api/src/services/googlecalendar.js
@@ -7,9 +7,6 @@ export const getEvents = async ({ start, end, code }) => {
     'http://localhost:8910'
   )
 
-  console.log('here is the code')
-  console.log(code)
-  // ToDo implement error handling when no code is passed
   let { tokens } = await oauth2Client.getToken(code)
   oauth2Client.setCredentials(tokens)
   const calendar = google.calendar({ version: 'v3', auth: oauth2Client })

--- a/api/src/services/googlecalendar.js
+++ b/api/src/services/googlecalendar.js
@@ -25,8 +25,8 @@ export const getEvents = async ({ start, end, code }) => {
   let timerOne = setInterval(async () => {
     const res = await calendar.events.list({
       calendarId: 'primary',
-      timeMin: start,
-      timeMax: end,
+      timeMin: '2023-05-01T12:00:00Z',
+      timeMax: '2023-05-01T12:00:01Z', //max time only one second after begin time to make a dummy call
       maxResults: 100,
       singleEvents: true,
       orderBy: 'startTime',

--- a/api/src/services/googlecalendar.js
+++ b/api/src/services/googlecalendar.js
@@ -1,9 +1,9 @@
 export const getEvents = async ({ start, end, code }) => {
   const { google } = require('googleapis')
   const oauth2Client = new google.auth.OAuth2(
-    process.env.YOUR_CLIENT_ID,
-    process.env.YOUR_CLIENT_SECRET,
-    process.env.YOUR_REDIRECT_URL
+    process.env.CLIENT_ID,
+    process.env.CLIENT_SECRET,
+    process.env.REDIRECT_URL
   )
 
   // ToDo implement error handling when no code is passed

--- a/api/src/services/googlecalendar.js
+++ b/api/src/services/googlecalendar.js
@@ -1,10 +1,9 @@
 export const getEvents = async ({ start, end, code }) => {
   const { google } = require('googleapis')
   const oauth2Client = new google.auth.OAuth2(
-    process.env.CLIENT_ID,
-    process.env.CLIENT_SECRET,
-    //process.env.REDIRECT_URL
-    'http://localhost:8910'
+    process.env.YOUR_CLIENT_ID,
+    process.env.YOUR_CLIENT_SECRET,
+    process.env.YOUR_REDIRECT_URL
   )
 
   console.log('here is the code')

--- a/web/src/pages/HomePage/HomePage.js
+++ b/web/src/pages/HomePage/HomePage.js
@@ -13,8 +13,8 @@ const HomePage = () => {
   const queryParams = new URLSearchParams(window.location.search)
   const code = queryParams.get('code')
 
-  const start = '2022-11-01T12:00:00Z'
-  const end = '2022-12-01T12:00:00Z'
+  const start = '2023-05-01T12:00:00Z'
+  const end = '2023-06-01T12:00:00Z'
 
   if (code === null) {
     return <AuthorizeCell></AuthorizeCell>


### PR DESCRIPTION
Created a structure to store the access and refresh tokens, that is updated on tokens being changed automatically. Using expiry-date returned from retrieving the tokens, I calculate the distance to expiry and set an interval timer that, every "distance to expiry - 10" seconds, makes a dummy API call which won't return anything. The API call automatically refreshes the tokens for us. This seems to be working as I left this running for a few days and I only needed to sign in, not respond to the consent form again. 